### PR TITLE
PropTypes was moved to 'prop-types' this follows that change

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/lib/sidebar.js
+++ b/lib/sidebar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   Text,

--- a/lib/title.js
+++ b/lib/title.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Text } from 'react-native';
 
 export default class Title extends Component {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/machadogj/react-native-components-viewer",
   "dependencies": {
+    "prop-types": "^15.7.2",
     "react-native-layout-tester": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR addresses an issue with a deprecated interface in `react-native-components-viewer` after an upstream change in [react v15.5.0](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html).


Also: I am not sure if this lib is still supported, but if it is I will make some other changes as it is very useful.